### PR TITLE
feat(fuzz): add fuzzing

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "zero-packet-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.zero-packet]
+path = ".."
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use zero_packet::packet::parser::PacketParser;
+
+fuzz_target!(|data: &[u8]| {
+    let parsed = PacketParser::parse(&data);
+});

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -4,5 +4,5 @@ use libfuzzer_sys::fuzz_target;
 use zero_packet::packet::parser::PacketParser;
 
 fuzz_target!(|data: &[u8]| {
-    let parsed = PacketParser::parse(&data);
+    let _parsed = PacketParser::parse(&data);
 });


### PR DESCRIPTION
https://rust-fuzz.github.io/book/cargo-fuzz/setup.html

Once you do:
```
rustup install nightly
cargo install cargo-fuzz
cargo +nightly fuzz run fuzz_target_1
```

You can see it will quickly create tons of inputs that will panic the library.

```
thread '<unnamed>' panicked at /home/matt/zero-packet/src/packet/parser.rs:100:54:
range start index 52 out of range for slice of length 50
```
https://github.com/J-Schoepplenberg/zero-packet/blob/main/src/packet/parser.rs#L99-L104
Base64: `CAAAAABuAABAQAAICABOADIAAAAAAAABLS8uLy8vLy8vfi8vLy8vLy8vLy8vLwAAAv7+/v7+/gAA/gBAAAAAABAAAAE=`

This specific error is easily fixable with a well-placed 
```rust
        if header_len > data.len() {
            return Err("Invalid length!")
        }
```
but it's good practice to have a fuzzer nonetheless